### PR TITLE
Integrate drf-spectacular for API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ rye run devserver
 ```
 rye run test
 ```
+## API Document
+You can access the API documentation in Swagger-UI format by navigating to `/api/docs/`, and in Redoc format by navigating to `/api/redoc/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 dependencies = [
     "django>=5.0.8",
     "djangorestframework>=3.15.2",
+    "drf-spectacular>=0.27.2",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -11,8 +11,30 @@
 
 asgiref==3.8.1
     # via django
+attrs==24.2.0
+    # via jsonschema
+    # via referencing
 django==5.0.8
     # via djangorestframework
+    # via drf-spectacular
 djangorestframework==3.15.2
+    # via drf-spectacular
+drf-spectacular==0.27.2
+inflection==0.5.1
+    # via drf-spectacular
+jsonschema==4.23.0
+    # via drf-spectacular
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+pyyaml==6.0.2
+    # via drf-spectacular
+referencing==0.35.1
+    # via jsonschema
+    # via jsonschema-specifications
+rpds-py==0.20.0
+    # via jsonschema
+    # via referencing
 sqlparse==0.5.1
     # via django
+uritemplate==4.1.1
+    # via drf-spectacular

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,8 +11,30 @@
 
 asgiref==3.8.1
     # via django
+attrs==24.2.0
+    # via jsonschema
+    # via referencing
 django==5.0.8
     # via djangorestframework
+    # via drf-spectacular
 djangorestframework==3.15.2
+    # via drf-spectacular
+drf-spectacular==0.27.2
+inflection==0.5.1
+    # via drf-spectacular
+jsonschema==4.23.0
+    # via drf-spectacular
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+pyyaml==6.0.2
+    # via drf-spectacular
+referencing==0.35.1
+    # via jsonschema
+    # via jsonschema-specifications
+rpds-py==0.20.0
+    # via jsonschema
+    # via referencing
 sqlparse==0.5.1
     # via django
+uritemplate==4.1.1
+    # via drf-spectacular

--- a/shoptrack/settings.py
+++ b/shoptrack/settings.py
@@ -32,54 +32,55 @@ ALLOWED_HOSTS = ["*"]
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'records.apps.RecordsConfig',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "records.apps.RecordsConfig",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'shoptrack.urls'
+ROOT_URLCONF = "shoptrack.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'shoptrack.wsgi.application'
+WSGI_APPLICATION = "shoptrack.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
 
@@ -89,16 +90,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -106,9 +107,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
-LANGUAGE_CODE = 'ja'
+LANGUAGE_CODE = "ja"
 
-TIME_ZONE = 'Asia/Tokyo'
+TIME_ZONE = "Asia/Tokyo"
 
 USE_I18N = True
 
@@ -118,9 +119,26 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = "static/"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Django REST framework settings
+# https://www.django-rest-framework.org/api-guide/settings/
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+# drf-spectacular setings
+# https://github.com/tfranzel/drf-spectacular/
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "shop-track API",
+    "DESCRIPTION": "This is the shop-track API",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+}

--- a/shoptrack/urls.py
+++ b/shoptrack/urls.py
@@ -14,10 +14,23 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('api/', include('records.urls')),
+    path("admin/", admin.site.urls),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/docs/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "api/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
+    path("api/", include("records.urls")),
 ]


### PR DESCRIPTION
- Add drf-spectacular to the project for generating API documentation.
- Configure API schema and documentation endpoints.
- Ensure that all API endpoints are properly documented and accessible via the documentation page.
- Update project settings and urls to include drf-spectacular views.