### PR TITLE
fix(ci): Correct Docker build context for backend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ./backend
           file: ./backend/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Updates the `deploy-backend.yml` workflow to set the Docker build context to `./backend`.

Previously, the context was set to the repository root (`.`), which is incorrect for a monorepo structure. This could lead to unnecessarily large build contexts and potential issues by including files from outside the backend directory (e.g., the `frontend` app).

This change ensures that only the files within the `backend` directory are sent to the Docker daemon, resulting in a faster, more efficient, and correct build process.